### PR TITLE
Update tests to use GH actions to work with more recent openssl versions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 40
 
     strategy:
-      fail-fast: false # TODO: switch to true once finished verifying everything works
+      fail-fast: true
       matrix:
         ruby:
           - 2.5

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,57 @@
+name: Verify
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    timeout-minutes: 40
+
+    strategy:
+      fail-fast: false # TODO: switch to true once finished verifying everything works
+      matrix:
+        ruby:
+          - 2.5
+          - 2.6
+          - 2.7
+          - 3.0
+        test_cmd:
+          - bundle exec rspec
+
+    env:
+      RAILS_ENV: test
+
+    name: Ruby ${{ matrix.ruby }} - ${{ matrix.test_cmd }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Setup bundler
+        run: |
+          gem install bundler
+      - uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+      - name: Bundle install
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: ${{ matrix.test_cmd }}
+        run: |
+          echo "${CMD}"
+          bash -c "${CMD}"
+        env:
+          CMD: ${{ matrix.test_cmd }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-group: stable
-cache: bundler
-language: ruby
-rvm:
-  - 2.3.2

--- a/rex-sslscan.gemspec
+++ b/rex-sslscan.gemspec
@@ -22,9 +22,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.2.0'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
 
   spec.add_runtime_dependency "rex-core"
   spec.add_runtime_dependency "rex-text"

--- a/rex-sslscan.gemspec
+++ b/rex-sslscan.gemspec
@@ -6,11 +6,11 @@ require 'rex/sslscan/version'
 Gem::Specification.new do |spec|
   spec.name          = "rex-sslscan"
   spec.version       = Rex::Sslscan::VERSION
-  spec.authors       = ["David Maloney"]
-  spec.email         = ["DMaloney@rapid7.com"]
+  spec.authors       = ['Metasploit Hackers']
+  spec.email         = ['msfdev@metasploit.com']
 
   spec.summary       = %q{Ruby Exploitation(REX) Library for scanning the SSL/TLS capabilities of a server}
-  spec.description   = %q{This library is a pure ruby implmenetation of the SSLScan tool originally written
+  spec.description   = %q{This library is a pure ruby implmentation of the SSLScan tool originally written
                           by Ian Ventura-Whiting. It currently depends on the system version of OpenSSL}
   spec.homepage      = "https://github.com/rapid7/rex-sslscan"
 

--- a/spec/rex/sslscan/result_spec.rb
+++ b/spec/rex/sslscan/result_spec.rb
@@ -146,6 +146,8 @@ RSpec.describe Rex::SSLScan::Result do
             :status => :accepted})
         rescue ArgumentError => e
           expect(e.message).to eq "unknown SSL method `SSLv2'."
+        rescue OpenSSL::OpenSSLError => e
+          expect(e.message).to eq "SSL_CTX_set_min_proto_version"
         end
       end
 
@@ -204,6 +206,8 @@ RSpec.describe Rex::SSLScan::Result do
             :status => :rejected})
         rescue ArgumentError => e
           expect(e.message).to eq "unknown SSL method `SSLv2'."
+        rescue OpenSSL::OpenSSLError => e
+          expect(e.message).to eq "SSL_CTX_set_min_proto_version"
         end
       end
 
@@ -375,6 +379,8 @@ RSpec.describe Rex::SSLScan::Result do
           expect(subject.supports_sslv2?).to eq true
         rescue ArgumentError => e
           expect(e.message).to eq "unknown SSL method `SSLv2'."
+        rescue OpenSSL::OpenSSLError => e
+          expect(e.message).to eq "SSL_CTX_set_min_proto_version"
         end
       end
     end
@@ -454,6 +460,8 @@ RSpec.describe Rex::SSLScan::Result do
         expect(subject.standards_compliant?).to eq false
       rescue ArgumentError => e
         expect(e.message).to eq "unknown SSL method `SSLv2'."
+      rescue OpenSSL::OpenSSLError => e
+        expect(e.message).to eq "SSL_CTX_set_min_proto_version"
       end
     end
 

--- a/spec/rex/sslscan/scanner_spec.rb
+++ b/spec/rex/sslscan/scanner_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Rex::SSLScan::Scanner do
       end
 
       it "scans a server that doesn't support the cipher" do
-        expect(subject.test_cipher(:SSLv3, "DHE-DSS-AES256-SHA")).to eq :rejected
+        expect(subject.test_cipher(:SSLv3, "TLS_CHACHA20_POLY1305_SHA256")).to eq :rejected
       end
     end
 


### PR DESCRIPTION
This PR replaces travis with Github actions

Also updates a handful of tests that fail on more recent versions of openssl (where by default SSLv2 isn't available) where they were updated they should now work with a greater range of openssl versions

test run here: https://github.com/dwelch-r7/rex-sslscan/actions/runs/551962679

Investigated as part of the ruby 3 upgrade here https://github.com/rapid7/metasploit-framework/issues/14666