### PR TITLE
Add a nil check to host

### DIFF
--- a/lib/rex/sslscan/scanner.rb
+++ b/lib/rex/sslscan/scanner.rb
@@ -40,6 +40,8 @@ class Scanner
   # Checks whether the scanner option has a valid configuration
   # @return [Boolean] True or False, the configuration is valid.
   def valid?
+    return false unless @host
+
     begin
       @host = Rex::Socket.getaddress(@host, true)
     rescue


### PR DESCRIPTION
The test suite for rex-sslscan is currently failing. It looks like the failures have been caused unintentionally after an update to the  rex-socket gem: https://github.com/rapid7/rex-socket/pull/27

This small PR adds a nil check to the host value, returning false if no host is set which makes the tests pass.

## Before
![image](https://user-images.githubusercontent.com/85949464/134032847-cc699cf7-2a5d-4757-b445-e7f05ea524ae.png)

## After
![image](https://user-images.githubusercontent.com/85949464/134032918-c58a2271-5ebb-431c-8ee5-b97a2cacf51c.png)
