### PR TITLE
Update Rapid7 vulnerability reference link

### DIFF
--- a/lib/rex/sslscan/result.rb
+++ b/lib/rex/sslscan/result.rb
@@ -156,7 +156,7 @@ class Result
 
     strong_cipher_ctx = OpenSSL::SSL::SSLContext.new(version)
     # OpenSSL Directive For Strong Ciphers
-    # See: http://www.rapid7.com/vulndb/lookup/ssl-weak-ciphers
+    # See: https://web.archive.org/web/20121125052802/http://www.rapid7.com/vulndb/lookup/ssl-weak-ciphers
     strong_cipher_ctx.ciphers = "ALL:!aNULL:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM"
 
     if strong_cipher_ctx.ciphers.flatten.include? cipher


### PR DESCRIPTION
This PR updates a reference link to point to the updated Rapid7 resource.

It also provides evidence that the tests are now passing after [this PR](https://github.com/rapid7/rex-socket/pull/41) in Rex-Socket was landed.